### PR TITLE
Improve viewmodel override

### DIFF
--- a/src/features/color_modulate.cpp
+++ b/src/features/color_modulate.cpp
@@ -15,10 +15,6 @@ namespace color_modulation
 	auto night_mode_state = false;
 	auto night_mode_first = false;
 
-	auto flViewmodel_offset_x = -1.f;
-	auto flViewmodel_offset_y = -1.f;
-	auto flViewmodel_offset_z = -1.f;
-
 	ConVar* viewmodel_fov = nullptr;
 	ConVar* debug_fov = nullptr;
 	ConVar* r_3dsky = nullptr;
@@ -85,15 +81,6 @@ namespace color_modulation
 			return true;
 
 		if (debug_model_fov != settings::misc::debug_fov)
-			return true;
-
-		if (flViewmodel_offset_x != settings::misc::viewmodel_offset_x)
-			return true;
-
-		if (flViewmodel_offset_y != settings::misc::viewmodel_offset_y)
-			return true;
-
-		if (flViewmodel_offset_z != settings::misc::viewmodel_offset_z)
 			return true;
 
 		return false;
@@ -227,24 +214,6 @@ namespace color_modulation
 			mat_force_tonemap_scale->m_fnChangeCallbacks.m_Size = 0;
 		}
 
-		if (!viewmodel_offset_x)
-		{
-			viewmodel_offset_x = g::cvar->find(xorstr_("viewmodel_offset_x"));
-			viewmodel_offset_x->m_fnChangeCallbacks.m_Size = 0;
-		}
-
-		if (!viewmodel_offset_y)
-		{
-			viewmodel_offset_y = g::cvar->find(xorstr_("viewmodel_offset_y"));
-			viewmodel_offset_y->m_fnChangeCallbacks.m_Size = 0;
-		}
-
-		if (!viewmodel_offset_z)
-		{
-			viewmodel_offset_z = g::cvar->find(xorstr_("viewmodel_offset_z"));
-			viewmodel_offset_z->m_fnChangeCallbacks.m_Size = 0;
-		}
-
 		if (!engine_focus)
 		{
 			engine_focus = g::cvar->find(xorstr_("engine_no_focus_sleep"));
@@ -267,23 +236,6 @@ namespace color_modulation
 		engine_focus->SetValue(0);
 		cl_threaded_bone_setup->SetValue(1); //Threaded bone setup for more fps, found this while typing "find bones" into the console.
 		//If you google its cvar name there should be reddit post about it and how it aparently boosts fps, the post is from 2015.
-
-		static auto backup_viewmodel_x = g::cvar->find("viewmodel_offset_x")->GetFloat();
-		static auto backup_viewmodel_y = g::cvar->find("viewmodel_offset_y")->GetFloat();
-		static auto backup_viewmodel_z = g::cvar->find("viewmodel_offset_z")->GetFloat();
-
-		if (settings::misc::override_viewmodel)
-		{
-			viewmodel_offset_x->SetValue(settings::misc::viewmodel_offset_x);
-			viewmodel_offset_y->SetValue(settings::misc::viewmodel_offset_y);
-			viewmodel_offset_z->SetValue(settings::misc::viewmodel_offset_z);
-		}
-		else
-		{
-			viewmodel_offset_x->SetValue(backup_viewmodel_x);
-			viewmodel_offset_y->SetValue(backup_viewmodel_y);
-			viewmodel_offset_z->SetValue(backup_viewmodel_z);
-		}
 	}
 
 	void set_material_tone()

--- a/src/hooks/hooks.cpp
+++ b/src/hooks/hooks.cpp
@@ -271,6 +271,25 @@ namespace hooks
 			globals::view_matrix::offset = (reinterpret_cast<DWORD>(&g::engine_client->WorldToScreenMatrix()) + 0x40);
 		}
 
+		if (settings::misc::override_viewmodel)
+		{
+			if (!g::local_player->m_bIsScoped() && !g::input->m_fCameraInThirdPerson) 
+			{
+				const auto viewmodel = g::entity_list->GetClientEntityFromHandle(g::local_player->m_hViewModel());
+				if (viewmodel)
+				{
+					Vector x, y, z, total_offset;
+
+					math::angle2vectors(view->angles, y);
+					math::angle2vectors(view->angles - QAngle{-90.0f, 0.0f, 0.0f}, z);
+					x.CrossProduct(y, z, x);
+					total_offset = x * -settings::misc::viewmodel_offset_x + y * settings::misc::viewmodel_offset_y - z * settings::misc::viewmodel_offset_z;
+					
+					viewmodel->GetBaseEntity()->SetAbsOrigin(viewmodel->GetRenderOrigin() + total_offset);
+				}
+			}
+		}
+
 		if (!g::local_player->m_bIsScoped())
 			view->fov = settings::misc::debug_fov;
 

--- a/src/hooks/hooks.cpp
+++ b/src/hooks/hooks.cpp
@@ -273,19 +273,38 @@ namespace hooks
 
 		if (settings::misc::override_viewmodel)
 		{
-			if (!g::local_player->m_bIsScoped() && !g::input->m_fCameraInThirdPerson) 
-			{
-				const auto viewmodel = g::entity_list->GetClientEntityFromHandle(g::local_player->m_hViewModel());
-				if (viewmodel)
+			if (g::local_player->IsAlive()) {
+				if (!g::local_player->m_bIsScoped() && !g::input->m_fCameraInThirdPerson)
 				{
-					Vector x, y, z, total_offset;
+					const auto viewmodel = g::entity_list->GetClientEntityFromHandle(g::local_player->m_hViewModel());
+					if (viewmodel)
+					{
+						Vector x, y, z, total_offset;
 
-					math::angle2vectors(view->angles, y);
-					math::angle2vectors(view->angles - QAngle{-90.0f, 0.0f, 0.0f}, z);
-					x.CrossProduct(y, z, x);
-					total_offset = x * -settings::misc::viewmodel_offset_x + y * settings::misc::viewmodel_offset_y - z * settings::misc::viewmodel_offset_z;
-					
-					viewmodel->GetBaseEntity()->SetAbsOrigin(viewmodel->GetRenderOrigin() + total_offset);
+						math::angle2vectors(view->angles, y);
+						math::angle2vectors(view->angles - QAngle{ -90.0f, 0.0f, 0.0f }, z);
+						x.CrossProduct(y, z, x);
+						total_offset = x * -settings::misc::viewmodel_offset_x + y * settings::misc::viewmodel_offset_y - z * settings::misc::viewmodel_offset_z;
+
+						viewmodel->GetBaseEntity()->SetAbsOrigin(viewmodel->GetRenderOrigin() + total_offset);
+					}
+				}
+			}
+			else if (auto observer_target = g::local_player->m_hObserverTarget()) {
+				if (!observer_target->m_bIsScoped() && g::local_player->m_iObserverMode() == 4 /* IN_EYE */)
+				{
+					const auto viewmodel = g::entity_list->GetClientEntityFromHandle(observer_target->m_hViewModel());
+					if (viewmodel)
+					{
+						Vector x, y, z, total_offset;
+
+						math::angle2vectors(view->angles, y);
+						math::angle2vectors(view->angles - QAngle{ -90.0f, 0.0f, 0.0f }, z);
+						x.CrossProduct(y, z, x);
+						total_offset = x * -settings::misc::viewmodel_offset_x + y * settings::misc::viewmodel_offset_y - z * settings::misc::viewmodel_offset_z;
+
+						viewmodel->GetBaseEntity()->SetAbsOrigin(viewmodel->GetRenderOrigin() + total_offset);
+					}
 				}
 			}
 		}

--- a/src/render/tabs/misc_tab.cpp
+++ b/src/render/tabs/misc_tab.cpp
@@ -127,13 +127,13 @@ namespace render
 					switch (settings::visuals::viewmodel_mode)
 					{
 					case 0:
-						ImGui::SliderFloatLeftAligned("Offset X:", &settings::misc::viewmodel_offset_x, -21.f, 21.f, "%.0f");
+						ImGui::SliderFloatLeftAligned("Offset X:", &settings::misc::viewmodel_offset_x, -25.f, 25.f, "%.1f");
 						break;
 					case 1:
-						ImGui::SliderFloatLeftAligned("Offset Y:", &settings::misc::viewmodel_offset_y, 0.f, 50.f, "%.0f");
+						ImGui::SliderFloatLeftAligned("Offset Y:", &settings::misc::viewmodel_offset_y, -25.f, 25.f, "%.1f");
 						break;
 					case 2:
-						ImGui::SliderFloatLeftAligned("Offset Z:", &settings::misc::viewmodel_offset_z, -30.f, 30.f, "%.0f");
+						ImGui::SliderFloatLeftAligned("Offset Z:", &settings::misc::viewmodel_offset_z, -25.f, 25.f, "%.1f");
 						break;
 					}
 


### PR DESCRIPTION
Using SetAbsOrigin avoids using Convars and lets us customize the viewmodel much more.